### PR TITLE
Update map plugin

### DIFF
--- a/plugins/map/xviewer-map-plugin.c
+++ b/plugins/map/xviewer-map-plugin.c
@@ -67,7 +67,7 @@ update_marker_image (ChamplainLabel *marker,
 	thumb = gtk_clutter_texture_new ();
 	gtk_clutter_texture_set_from_icon_name (GTK_CLUTTER_TEXTURE (thumb),
 						widget,
-						"image-x-generic",
+	                                        "mark-location",
 						size, NULL);
 	/* don't need to unref widget because it is floating */
 

--- a/plugins/map/xviewer-map-plugin.c
+++ b/plugins/map/xviewer-map-plugin.c
@@ -67,7 +67,7 @@ update_marker_image (ChamplainLabel *marker,
 	thumb = gtk_clutter_texture_new ();
 	gtk_clutter_texture_set_from_icon_name (GTK_CLUTTER_TEXTURE (thumb),
 						widget,
-						"gnome-mime-image",
+						"image-x-generic",
 						size, NULL);
 	/* don't need to unref widget because it is floating */
 

--- a/plugins/map/xviewer-map-plugin.c
+++ b/plugins/map/xviewer-map-plugin.c
@@ -376,6 +376,12 @@ prepared_cb (XviewerWindow *window,
 	 */
 	selection_changed_cb (XVIEWER_THUMB_VIEW (plugin->thumbview), plugin);
 
+	/* zoom in and the be sure that all markers are visible.
+	 * This is useful to have a good starting zoom level where
+	 * you can see a available markers on the map
+	 */
+	champlain_view_set_zoom_level (plugin->map, 15);
+	champlain_view_ensure_layers_visible (plugin->map, FALSE);
 }
 
 static void

--- a/plugins/map/xviewer-map-plugin.c
+++ b/plugins/map/xviewer-map-plugin.c
@@ -349,6 +349,7 @@ static void
 prepared_cb (XviewerWindow *window,
 	     XviewerMapPlugin *plugin)
 {
+	GList *markers;
 
 	plugin->store = xviewer_window_get_store (plugin->window);
 
@@ -380,8 +381,13 @@ prepared_cb (XviewerWindow *window,
 	 * This is useful to have a good starting zoom level where
 	 * you can see a available markers on the map
 	 */
-	champlain_view_set_zoom_level (plugin->map, 15);
-	champlain_view_ensure_layers_visible (plugin->map, FALSE);
+	markers = champlain_marker_layer_get_markers (plugin->layer);
+	if(markers != NULL)
+	{
+		champlain_view_set_zoom_level (plugin->map, 15);
+		champlain_view_ensure_layers_visible (plugin->map, FALSE);
+		g_list_free (markers);
+	}
 }
 
 static void

--- a/plugins/map/xviewer-map-plugin.c
+++ b/plugins/map/xviewer-map-plugin.c
@@ -399,7 +399,8 @@ impl_activate (XviewerWindowActivatable *activatable)
 	vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
 	bbox = gtk_toolbar_new ();
 
-	button = GTK_WIDGET (gtk_tool_button_new_from_stock (GTK_STOCK_JUMP_TO));
+	button = GTK_WIDGET (gtk_tool_button_new (NULL, NULL));
+	gtk_tool_button_set_icon_name (GTK_TOOL_BUTTON (button), "go-jump-symbolic");
 	gtk_widget_set_tooltip_text (button, _("Jump to current image's location"));
 	g_signal_connect (button,
 			  "clicked",
@@ -411,7 +412,8 @@ impl_activate (XviewerWindowActivatable *activatable)
 	button = GTK_WIDGET (gtk_separator_tool_item_new ());
 	gtk_container_add (GTK_CONTAINER (bbox), button);
 
-	button = GTK_WIDGET (gtk_tool_button_new_from_stock (GTK_STOCK_ZOOM_IN));
+	button = GTK_WIDGET (gtk_tool_button_new (NULL, NULL));
+	gtk_tool_button_set_icon_name (GTK_TOOL_BUTTON (button), "zoom-in-symbolic");
 	gtk_widget_set_tooltip_text (button, _("Zoom in"));
 	g_signal_connect (button,
 			  "clicked",
@@ -419,7 +421,8 @@ impl_activate (XviewerWindowActivatable *activatable)
 			  plugin->map);
 	gtk_container_add (GTK_CONTAINER (bbox), button);
 
-	button = GTK_WIDGET (gtk_tool_button_new_from_stock (GTK_STOCK_ZOOM_OUT));
+	button = GTK_WIDGET (gtk_tool_button_new (NULL, NULL));
+	gtk_tool_button_set_icon_name (GTK_TOOL_BUTTON (button), "zoom-out-symbolic");
 	gtk_widget_set_tooltip_text (button, _("Zoom out"));
 	g_signal_connect (button,
 			  "clicked",

--- a/plugins/map/xviewer-map-plugin.c
+++ b/plugins/map/xviewer-map-plugin.c
@@ -58,17 +58,31 @@ xviewer_map_plugin_finalize (GObject *object)
 
 static void
 update_marker_image (ChamplainLabel *marker,
-		     GtkIconSize size)
+                     GtkIconSize size)
 {
 	GtkWidget *widget;
 	ClutterActor *thumb;
 
 	widget = gtk_button_new ();
 	thumb = gtk_clutter_texture_new ();
-	gtk_clutter_texture_set_from_icon_name (GTK_CLUTTER_TEXTURE (thumb),
-						widget,
-	                                        "mark-location",
-						size, NULL);
+	if (G_UNLIKELY (!gtk_clutter_texture_set_from_icon_name (GTK_CLUTTER_TEXTURE (thumb),
+	                                                         widget,
+	                                                         "mark-location",
+	                                                         size, NULL)))
+	{
+		/* mark-location doesn't appear to be a "standard" icon yet,
+		 * so try falling back to image-x-generic as before if
+		 * it is not available */
+		if (G_UNLIKELY (!gtk_clutter_texture_set_from_icon_name (GTK_CLUTTER_TEXTURE (thumb),
+		                                                         widget,
+		                                                         "image-x-generic",
+		                                                         size, NULL)))
+		{
+			g_warning ("Could not load icon for map marker. "
+			           "Please install a suitable icon theme!");
+		}
+	}
+
 	/* don't need to unref widget because it is floating */
 
 	champlain_label_set_image (marker, thumb);

--- a/plugins/map/xviewer-map-plugin.c
+++ b/plugins/map/xviewer-map-plugin.c
@@ -412,6 +412,7 @@ impl_activate (XviewerWindowActivatable *activatable)
 	g_object_set (G_OBJECT (plugin->map),
 		"zoom-level", 3,
 		"kinetic-mode", TRUE,
+		"goto-animation-duration", 1000,
 		NULL);
 	scale = champlain_scale_new ();
 	champlain_scale_connect_view (CHAMPLAIN_SCALE (scale), plugin->map);

--- a/plugins/map/xviewer-map-plugin.c
+++ b/plugins/map/xviewer-map-plugin.c
@@ -265,9 +265,9 @@ selection_changed_cb (XviewerThumbView *view,
 			      "longitude", &lon,
 			      NULL);
 
-		champlain_view_center_on (CHAMPLAIN_VIEW (plugin->map),
-					  lat,
-					  lon);
+		champlain_view_go_to (CHAMPLAIN_VIEW (plugin->map),
+		                      lat,
+		                      lon);
 
 		/* Reset the previous selection */
 		if (plugin->marker)
@@ -304,9 +304,9 @@ jump_to (GtkWidget *widget,
 		      "longitude", &lon,
 		      NULL);
 
-	champlain_view_center_on (CHAMPLAIN_VIEW (plugin->map),
-				  lat,
-				  lon);
+	champlain_view_go_to (CHAMPLAIN_VIEW (plugin->map),
+	                      lat,
+	                      lon);
 }
 
 static void


### PR DESCRIPTION
Capture map plugin updates on eog-plugins.

- In xviewer-map-plugin.c, deprecated icons is currently used. For example, the icon "gnome-mime-image" is currently used to mark the position of images on the map display.  This icon is only available in the *deprecated/outdated* module gnome-icon-theme. Instead, this PR introduces that "mark-location" icon shall be used if available and the standard icon "image-x-generic" shall be used if no.  
  - map: Fall back to old marker icon if the new one isn't available
  - map: Use location marker icon
  - map: Use a non-deprecated image icon
  - map: Replace deprecated stock icons with named symbolic icons 
- When navigating through images while showing the map, the center of the map is currently changed directly (direct jump to the new center) without any transition/animation. Using libchamplains "champlain_view_go_to()" function slowly moves from one location to the next when showing the next image. This is a much better experience and you can visually follow from where you go to the next image.
  - map: Slowly move to selected image instead of a quick jump
  - map: Set move duration to 1sec
- When opening the map plugin, the initial zoom level is currently wrong. The map shows a lot of the world while the picture (or multiple pictures) are usually from a given area. This PR make all given markers visible on the initial zoom level.
  - map: Only set initial zoom if markers are actually present
  - map: Use meaningful initial zoom level