### PR TITLE
Some misc build improvements

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,8 +4,8 @@ Priority: optional
 Maintainer: Linux Mint <root@linuxmint.com>
 Build-Depends: debhelper-compat (= 12),
                dh-python,
+               gettext,
                gsettings-desktop-schemas-dev,
-               intltool (>= 0.40.0),
                libchamplain-0.12-dev,
                libchamplain-gtk-0.12-dev,
                libclutter-1.0-dev (>= 1.9.4),

--- a/debian/control
+++ b/debian/control
@@ -17,6 +17,7 @@ Build-Depends: debhelper-compat (= 12),
                libgtk-3-dev (>= 3.3.8),
                libpeas-dev (>= 0.7.4),
                libxapp-dev,
+               meson,
                python3-all (>= 3.6),
                xviewer-dev (>= 3.2.1)
 Standards-Version: 4.5.0

--- a/install-scripts/meson.build
+++ b/install-scripts/meson.build
@@ -1,0 +1,15 @@
+# These scripts run as post-installation scripts.
+
+# They're designed to do nothing if DESTDIR is set, which happens
+# during debian builds for instance - there's a fake install target
+# so running these would be pointless.
+
+# When using deb packaging, these aren't needed, as these operations
+# are run automatically by the package manager.
+
+# They're really only necessary in straight builds where 'ninja install'
+# will be run directly, to install the program onto the system.
+
+
+# Re-compile gsettings
+meson.add_install_script('meson_install_schemas.py')

--- a/install-scripts/meson_install_schemas.py
+++ b/install-scripts/meson_install_schemas.py
@@ -1,0 +1,10 @@
+#!/usr/bin/python3
+
+import os
+import subprocess
+
+schemadir = os.path.join(os.environ['MESON_INSTALL_PREFIX'], 'share', 'glib-2.0', 'schemas')
+
+if not os.environ.get('DESTDIR'):
+    print('Compiling gsettings schemas...')
+    subprocess.call(['glib-compile-schemas', schemadir])

--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,5 @@ config_h = declare_dependency(
 add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
 add_project_arguments('-Wno-deprecated-declarations', language: 'c')
 
-intltool_merge = find_program('intltool-merge')
-
 subdir('plugins')
 subdir('po')

--- a/meson.build
+++ b/meson.build
@@ -54,5 +54,6 @@ config_h = declare_dependency(
 add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
 add_project_arguments('-Wno-deprecated-declarations', language: 'c')
 
+subdir('install-scripts')
 subdir('plugins')
 subdir('po')

--- a/plugins/exif-display/exif-display.plugin.desktop.in
+++ b/plugins/exif-display/exif-display.plugin.desktop.in
@@ -1,9 +1,9 @@
 [Plugin]
 Module=exif-display
 IAge=2
-_Name=Exif Display
+Name=Exif Display
+Description=Displays camera settings and histogram
 Icon=zoom-fit-best-symbolic
-_Description=Displays camera settings and histogram
 Authors=Emmanuel Touzery
 Copyright=Copyright © 2009 Emmanuel Touzery
 Website=http://github.com/linuxmint/xviewer

--- a/plugins/exif-display/meson.build
+++ b/plugins/exif-display/meson.build
@@ -1,20 +1,21 @@
 plugin_name = 'exif-display'
 
 # plugin info
-custom_target(
-    '@0@-plugin-info'.format(plugin_name),
+i18n.merge_file(
     input: '@0@.plugin.desktop.in'.format(plugin_name),
     output: '@0@.plugin'.format(plugin_name),
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'desktop',
+    args: ['--keyword=Name', '--keyword=Description'],
+    po_dir: po_dir,
     install: true,
     install_dir: plugin_libdir,
 )
 
-custom_target(
-    '@0@-metadata'.format(plugin_name),
+i18n.merge_file(
     input: 'xviewer-@0@.metainfo.xml.in'.format(plugin_name),
     output: 'xviewer-@0@.metainfo.xml'.format(plugin_name),
-    command: [intltool_merge, '-x', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'xml',
+    po_dir: po_dir,
     install: true,
     install_dir: metainfo_dir
 )

--- a/plugins/exif-display/xviewer-exif-display.metainfo.xml.in
+++ b/plugins/exif-display/xviewer-exif-display.metainfo.xml.in
@@ -3,8 +3,8 @@
 <component type="addon">
   <id>xviewer-exif-display</id>
   <extends>xviewer.desktop</extends>
-  <_name>Exif Display</_name>
-  <_summary>Displays Exif tags in the side panel and optionally the statusbar</_summary>
+  <name>Exif Display</name>
+  <summary>Displays Exif tags in the side panel and optionally the statusbar</summary>
   <url type="homepage">https://github.com/linuxmint/xviewer-plugins</url>
   <url type="bugtracker">https://github.com/linuxmint/xviewer-plugins/issues</url>
   <metadata_license>CC0-1.0</metadata_license>

--- a/plugins/export-to-folder/export-to-folder.plugin.desktop.in
+++ b/plugins/export-to-folder/export-to-folder.plugin.desktop.in
@@ -2,9 +2,9 @@
 Loader=python3
 Module=export-to-folder
 IAge=2
-_Name=Export to Folder
+Name=Export to Folder
 Icon=folder-symbolic
-_Description=Export the current image to a separate directory
+Description=Export the current image to a separate directory
 Authors=Jendrik Seipp <jendrikseipp@web.de>
 Copyright=Copyright © 2012 Jendrik Seipp
 Website=https://bitbucket.org/jendrikseipp/xviewer-export

--- a/plugins/export-to-folder/meson.build
+++ b/plugins/export-to-folder/meson.build
@@ -1,19 +1,20 @@
 plugin_name = 'export-to-folder'
 
-custom_target(
-    '@0@-plugin-info'.format(plugin_name),
+i18n.merge_file(
     input: '@0@.plugin.desktop.in'.format(plugin_name),
     output: '@0@.plugin'.format(plugin_name),
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'desktop',
+    args: ['--keyword=Name', '--keyword=Description'],
+    po_dir: po_dir,
     install: true,
     install_dir: plugin_libdir,
 )
 
-custom_target(
-    '@0@-metadata'.format(plugin_name),
+i18n.merge_file(
     input: 'xviewer-@0@.metainfo.xml.in'.format(plugin_name),
     output: 'xviewer-@0@.metainfo.xml'.format(plugin_name),
-    command: [intltool_merge, '-x', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'xml',
+    po_dir: po_dir,
     install: true,
     install_dir: metainfo_dir
 )

--- a/plugins/export-to-folder/xviewer-export-to-folder.metainfo.xml.in
+++ b/plugins/export-to-folder/xviewer-export-to-folder.metainfo.xml.in
@@ -3,8 +3,8 @@
 <component type="addon">
   <id>xviewer-export-to-folder</id>
   <extends>xviewer.desktop</extends>
-  <_name>Export to Folder</_name>
-  <_summary>Export the current image to a separate directory</_summary>
+  <name>Export to Folder</name>
+  <summary>Export the current image to a separate directory</summary>
   <url type="homepage">https://github.com/linuxmint/xviewer-plugins</url>
   <url type="bugtracker">https://github.com/linuxmint/xviewer-plugins/issues</url>
   <metadata_license>CC0-1.0</metadata_license>

--- a/plugins/light-theme/light-theme.plugin.desktop.in
+++ b/plugins/light-theme/light-theme.plugin.desktop.in
@@ -1,9 +1,9 @@
 [Plugin]
 Module=light-theme
 IAge=2
-_Name=Disable Dark Theme
+Name=Disable Dark Theme
 Icon=preferences-color-symbolic
-_Description=Disables xviewer's preference of dark theme variants
+Description=Disables xviewer's preference of dark theme variants
 Authors=Felix Riemann <friemann@gnome.org>
 Copyright=Copyright © 2012 Felix Riemann
 Website=http://github.com/linuxmint/xviewer

--- a/plugins/light-theme/meson.build
+++ b/plugins/light-theme/meson.build
@@ -1,20 +1,21 @@
 plugin_name = 'light-theme'
 
 # plugin info
-custom_target(
-    '@0@-plugin-info'.format(plugin_name),
+i18n.merge_file(
     input: '@0@.plugin.desktop.in'.format(plugin_name),
     output: '@0@.plugin'.format(plugin_name),
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'desktop',
+    args: ['--keyword=Name', '--keyword=Description'],
+    po_dir: po_dir,
     install: true,
     install_dir: plugin_libdir,
 )
 
-custom_target(
-    '@0@-metadata'.format(plugin_name),
+i18n.merge_file(
     input: 'xviewer-@0@.metainfo.xml.in'.format(plugin_name),
     output: 'xviewer-@0@.metainfo.xml'.format(plugin_name),
-    command: [intltool_merge, '-x', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'xml',
+    po_dir: po_dir,
     install: true,
     install_dir: metainfo_dir
 )

--- a/plugins/light-theme/xviewer-light-theme.metainfo.xml.in
+++ b/plugins/light-theme/xviewer-light-theme.metainfo.xml.in
@@ -3,8 +3,8 @@
 <component type="addon">
   <id>xviewer-light-theme</id>
   <extends>xviewer.desktop</extends>
-  <_name>Disable Dark Theme</_name>
-  <_summary>Disables dark theme</_summary>
+  <name>Disable Dark Theme</name>
+  <summary>Disables dark theme</summary>
   <url type="homepage">https://github.com/linuxmint/xviewer-plugins</url>
   <url type="bugtracker">https://github.com/linuxmint/xviewer-plugins/issues</url>
   <metadata_license>CC0-1.0</metadata_license>

--- a/plugins/map/map.plugin.desktop.in
+++ b/plugins/map/map.plugin.desktop.in
@@ -1,9 +1,9 @@
 [Plugin]
 Module=map
 IAge=2
-_Name=Map
+Name=Map
 Icon=mark-location-symbolic
-_Description=Display the geolocation of the image on a map
+Description=Display the geolocation of the image on a map
 Authors=Pierre-Luc Beaudoin <pierre-luc@pierlux.com>
 Copyright=Copyright © 2008, 2010 Pierre-Luc Beaudoin
 Website=http://projects.gnome.org/libchamplain

--- a/plugins/map/meson.build
+++ b/plugins/map/meson.build
@@ -1,20 +1,21 @@
 plugin_name = 'map'
 
 # plugin info
-custom_target(
-    '@0@-plugin-info'.format(plugin_name),
+i18n.merge_file(
     input: '@0@.plugin.desktop.in'.format(plugin_name),
     output: '@0@.plugin'.format(plugin_name),
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'desktop',
+    args: ['--keyword=Name', '--keyword=Description'],
+    po_dir: po_dir,
     install: true,
     install_dir: plugin_libdir,
 )
 
-custom_target(
-    '@0@-metadata'.format(plugin_name),
+i18n.merge_file(
     input: 'xviewer-@0@.metainfo.xml.in'.format(plugin_name),
     output: 'xviewer-@0@.metainfo.xml'.format(plugin_name),
-    command: [intltool_merge, '-x', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'xml',
+    po_dir: po_dir,
     install: true,
     install_dir: metainfo_dir
 )

--- a/plugins/map/xviewer-map-plugin.c
+++ b/plugins/map/xviewer-map-plugin.c
@@ -45,7 +45,10 @@ static void
 xviewer_map_plugin_init (XviewerMapPlugin *plugin)
 {
 	xviewer_debug_message (DEBUG_PLUGINS, "XviewerMapPlugin initializing");
-	gtk_clutter_init (NULL, NULL);
+	if (gtk_clutter_init (NULL, NULL) != CLUTTER_INIT_SUCCESS)
+	{
+		g_warning ("XviewerMapPlugin: gtk_clutter_init failed!");
+	}
 }
 
 static void

--- a/plugins/map/xviewer-map.metainfo.xml.in
+++ b/plugins/map/xviewer-map.metainfo.xml.in
@@ -3,8 +3,8 @@
 <component type="addon">
   <id>xviewer-map</id>
   <extends>xviewer.desktop</extends>
-  <_name>Map</_name>
-  <_summary>Displays on a map in the side panel where the picture was taken</_summary>
+  <name>Map</name>
+  <summary>Displays on a map in the side panel where the picture was taken</summary>
   <url type="homepage">https://github.com/linuxmint/xviewer-plugins</url>
   <url type="bugtracker">https://github.com/linuxmint/xviewer-plugins/issues</url>
   <metadata_license>CC0-1.0</metadata_license>

--- a/plugins/postasa/meson.build
+++ b/plugins/postasa/meson.build
@@ -1,19 +1,20 @@
 plugin_name = 'postasa'
 
-custom_target(
-    '@0@-plugin-info'.format(plugin_name),
+i18n.merge_file(
     input: '@0@.plugin.desktop.in'.format(plugin_name),
     output: '@0@.plugin'.format(plugin_name),
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'desktop',
+    args: ['--keyword=Name', '--keyword=Description'],
+    po_dir: po_dir,
     install: true,
     install_dir: plugin_libdir,
 )
 
-custom_target(
-    '@0@-metadata'.format(plugin_name),
+i18n.merge_file(
     input: 'xviewer-@0@.metainfo.xml.in'.format(plugin_name),
     output: 'xviewer-@0@.metainfo.xml'.format(plugin_name),
-    command: [intltool_merge, '-x', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'xml',
+    po_dir: po_dir,
     install: true,
     install_dir: metainfo_dir
 )

--- a/plugins/postasa/postasa.plugin.desktop.in
+++ b/plugins/postasa/postasa.plugin.desktop.in
@@ -1,9 +1,9 @@
 [Plugin]
 Module=postasa
 IAge=2
-_Name=PicasaWeb Uploader
+Name=PicasaWeb Uploader
 Icon=emblem-shared-symbolic
-_Description=Upload your pictures to PicasaWeb
+Description=Upload your pictures to PicasaWeb
 Authors=Richard Schwarting <aquarichy@gmail.com>
 Copyright=Copyright © 2009 Richard Schwarting
 Website=http://github.com/linuxmint/xviewer

--- a/plugins/postasa/xviewer-postasa-plugin.c
+++ b/plugins/postasa/xviewer-postasa-plugin.c
@@ -50,11 +50,6 @@ enum {
 static void
 xviewer_window_activatable_iface_init (XviewerWindowActivatableInterface *iface);
 
-G_DEFINE_DYNAMIC_TYPE_EXTENDED (XviewerPostasaPlugin, xviewer_postasa_plugin,
-		PEAS_TYPE_EXTENSION_BASE, 0,
-		G_IMPLEMENT_INTERFACE_DYNAMIC(XVIEWER_TYPE_WINDOW_ACTIVATABLE,
-					xviewer_window_activatable_iface_init))
-
 /**
  * _XviewerPostasaPluginPrivate:
  *
@@ -86,6 +81,12 @@ struct _XviewerPostasaPluginPrivate
 	GtkTreeView  *uploads_view;
 	GtkListStore *uploads_store;
 };
+
+G_DEFINE_DYNAMIC_TYPE_EXTENDED (XviewerPostasaPlugin, xviewer_postasa_plugin,
+		PEAS_TYPE_EXTENSION_BASE, 0,
+		G_ADD_PRIVATE_DYNAMIC (XviewerPostasaPlugin)
+		G_IMPLEMENT_INTERFACE_DYNAMIC(XVIEWER_TYPE_WINDOW_ACTIVATABLE,
+					xviewer_window_activatable_iface_init))
 
 /**
  * PicasaWebUploadFileAsyncData:
@@ -860,7 +861,7 @@ xviewer_postasa_plugin_init (XviewerPostasaPlugin *plugin)
 {
 	xviewer_debug_message (DEBUG_PLUGINS, "XviewerPostasaPlugin initializing");
 
-	plugin->priv = G_TYPE_INSTANCE_GET_PRIVATE (plugin, XVIEWER_TYPE_POSTASA_PLUGIN, XviewerPostasaPluginPrivate);
+	plugin->priv = xviewer_postasa_plugin_get_instance_private (plugin);
 
 #ifdef HAVE_LIBGDATA_0_9
 	plugin->priv->authorizer = gdata_client_login_authorizer_new ("XviewerPostasa", GDATA_TYPE_PICASAWEB_SERVICE);
@@ -962,8 +963,6 @@ static void
 xviewer_postasa_plugin_class_init (XviewerPostasaPluginClass *klass)
 {
 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
-
-	g_type_class_add_private (klass, sizeof (XviewerPostasaPluginPrivate));
 
 	object_class->dispose = xviewer_postasa_plugin_dispose;
 	object_class->set_property = xviewer_postasa_plugin_set_property;

--- a/plugins/postasa/xviewer-postasa.metainfo.xml.in
+++ b/plugins/postasa/xviewer-postasa.metainfo.xml.in
@@ -2,8 +2,8 @@
 <component type="addon">
   <id>xviewer-postasa</id>
   <extends>xviewer.desktop</extends>
-  <_name>Picasa Web Uploader</_name>
-  <_summary>Supports uploading photos to Google Picasa Web</_summary>
+  <name>Picasa Web Uploader</name>
+  <summary>Supports uploading photos to Google Picasa Web</summary>
   <url type="homepage">https://github.com/linuxmint/xviewer-plugins</url>
   <url type="bugtracker">https://github.com/linuxmint/xviewer-plugins/issues</url>
   <metadata_license>CC0-1.0</metadata_license>

--- a/plugins/postr/meson.build
+++ b/plugins/postr/meson.build
@@ -1,20 +1,21 @@
 plugin_name = 'postr'
 
 # plugin info
-custom_target(
-    '@0@-plugin-info'.format(plugin_name),
+i18n.merge_file(
     input: '@0@.plugin.desktop.in'.format(plugin_name),
     output: '@0@.plugin'.format(plugin_name),
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'desktop',
+    args: ['--keyword=Name', '--keyword=Description'],
+    po_dir: po_dir,
     install: true,
     install_dir: plugin_libdir,
 )
 
-custom_target(
-    '@0@-metadata'.format(plugin_name),
+i18n.merge_file(
     input: 'xviewer-@0@.metainfo.xml.in'.format(plugin_name),
     output: 'xviewer-@0@.metainfo.xml'.format(plugin_name),
-    command: [intltool_merge, '-x', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'xml',
+    po_dir: po_dir,
     install: true,
     install_dir: metainfo_dir
 )

--- a/plugins/postr/postr.plugin.desktop.in
+++ b/plugins/postr/postr.plugin.desktop.in
@@ -1,9 +1,9 @@
 [Plugin]
 Module=postr
 IAge=2
-_Name=Flickr Uploader
+Name=Flickr Uploader
 Icon=emblem-shared-symbolic
-_Description=Upload your pictures to Flickr
+Description=Upload your pictures to Flickr
 Authors=Lucas Rocha <lucasr@gnome.org>
 Copyright=Copyright © 2007 Lucas Rocha
 Website=http://github.com/linuxmint/xviewer

--- a/plugins/postr/xviewer-postr.metainfo.xml.in
+++ b/plugins/postr/xviewer-postr.metainfo.xml.in
@@ -3,8 +3,8 @@
 <component type="addon">
   <id>xviewer-postr</id>
   <extends>xviewer.desktop</extends>
-  <_name>Postr</_name>
-  <_summary>Supports uploading photos to Flickr</_summary>
+  <name>Postr</name>
+  <summary>Supports uploading photos to Flickr</summary>
   <url type="homepage">https://github.com/linuxmint/xviewer-plugins</url>
   <url type="bugtracker">https://github.com/linuxmint/xviewer-plugins/issues</url>
   <metadata_license>CC0-1.0</metadata_license>

--- a/plugins/pythonconsole/meson.build
+++ b/plugins/pythonconsole/meson.build
@@ -1,19 +1,20 @@
 plugin_name = 'pythonconsole'
 
-custom_target(
-    '@0@-plugin-info'.format(plugin_name),
+i18n.merge_file(
     input: '@0@.plugin.desktop.in'.format(plugin_name),
     output: '@0@.plugin'.format(plugin_name),
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'desktop',
+    args: ['--keyword=Name', '--keyword=Description'],
+    po_dir: po_dir,
     install: true,
     install_dir: plugin_libdir,
 )
 
-custom_target(
-    '@0@-metadata'.format(plugin_name),
+i18n.merge_file(
     input: 'xviewer-@0@.metainfo.xml.in'.format(plugin_name),
     output: 'xviewer-@0@.metainfo.xml'.format(plugin_name),
-    command: [intltool_merge, '-x', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'xml',
+    po_dir: po_dir,
     install: true,
     install_dir: metainfo_dir
 )

--- a/plugins/pythonconsole/pythonconsole.plugin.desktop.in
+++ b/plugins/pythonconsole/pythonconsole.plugin.desktop.in
@@ -2,8 +2,8 @@
 Loader=python3
 Module=pythonconsole
 IAge=2
-_Name=Python Console
-_Description=Python console for xviewer
+Name=Python Console
+Description=Python console for xviewer
 Icon=applications-engineering-symbolic
 Authors=Diego Escalante Urrelo <diegoe@gnome.org>
 Copyright=Copyright © 2008 Diego Escalante Urrelo

--- a/plugins/pythonconsole/xviewer-pythonconsole.metainfo.xml.in
+++ b/plugins/pythonconsole/xviewer-pythonconsole.metainfo.xml.in
@@ -3,8 +3,8 @@
 <component type="addon">
   <id>xviewer-pythonconsole</id>
   <extends>xviewer.desktop</extends>
-  <_name>Python Console</_name>
-  <_summary>Adds a Python console</_summary>
+  <name>Python Console</name>
+  <summary>Adds a Python console</summary>
   <url type="homepage">https://github.com/linuxmint/xviewer-plugins</url>
   <url type="bugtracker">https://github.com/linuxmint/xviewer-plugins/issues</url>
   <metadata_license>CC0-1.0</metadata_license>

--- a/plugins/send-by-mail/meson.build
+++ b/plugins/send-by-mail/meson.build
@@ -1,20 +1,21 @@
 plugin_name = 'send-by-mail'
 
 # plugin info
-custom_target(
-    '@0@-plugin-info'.format(plugin_name),
+i18n.merge_file(
     input: '@0@.plugin.desktop.in'.format(plugin_name),
     output: '@0@.plugin'.format(plugin_name),
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'desktop',
+    args: ['--keyword=Name', '--keyword=Description'],
+    po_dir: po_dir,
     install: true,
     install_dir: plugin_libdir,
 )
 
-custom_target(
-    '@0@-metadata'.format(plugin_name),
+i18n.merge_file(
     input: 'xviewer-@0@.metainfo.xml.in'.format(plugin_name),
     output: 'xviewer-@0@.metainfo.xml'.format(plugin_name),
-    command: [intltool_merge, '-x', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'xml',
+    po_dir: po_dir,
     install: true,
     install_dir: metainfo_dir
 )

--- a/plugins/send-by-mail/send-by-mail.plugin.desktop.in
+++ b/plugins/send-by-mail/send-by-mail.plugin.desktop.in
@@ -1,9 +1,9 @@
 [Plugin]
 Module=send-by-mail
 IAge=2
-_Name=Send By Mail
+Name=Send By Mail
 Icon=mail-send-symbolic
-_Description=Sends an image attached to a new mail
+Description=Sends an image attached to a new mail
 Authors=Felix Riemann <friemann@gnome.org>
 Copyright=Copyright © 2009 Felix Riemann
 Website=http://github.com/linuxmint/xviewer

--- a/plugins/send-by-mail/xviewer-send-by-mail-plugin.c
+++ b/plugins/send-by-mail/xviewer-send-by-mail-plugin.c
@@ -113,7 +113,9 @@ impl_deactivate	(XviewerWindowActivatable *activatable)
 
 	gtk_ui_manager_remove_action_group (manager,
 					    plugin->ui_action_group);
-	plugin->ui_action_group = NULL;
+	gtk_ui_manager_ensure_update (manager);
+
+	g_clear_object (&plugin->ui_action_group);
 	plugin->ui_menuitem_id = 0;
 }
 

--- a/plugins/send-by-mail/xviewer-send-by-mail-plugin.c
+++ b/plugins/send-by-mail/xviewer-send-by-mail-plugin.c
@@ -198,7 +198,6 @@ xviewer_window_activatable_iface_init (XviewerWindowActivatableInterface *iface)
 static void
 send_by_mail_cb (GtkAction *action, XviewerWindow *window)
 {
-	GdkScreen *screen = NULL;
 	GtkWidget *tview = NULL;
 	GList *images = NULL, *image = NULL;
 	gboolean first = TRUE;
@@ -207,9 +206,6 @@ send_by_mail_cb (GtkAction *action, XviewerWindow *window)
 	gchar *argv[] = { "thunderbird", "-compose", NULL, NULL };
 
 	g_return_if_fail (XVIEWER_IS_WINDOW (window));
-
-	if (gtk_widget_has_screen (GTK_WIDGET (window)))
-		screen = gtk_widget_get_screen (GTK_WIDGET (window));
 
 	tview = xviewer_window_get_thumb_view (window);
 	images = xviewer_thumb_view_get_selected_images (XVIEWER_THUMB_VIEW (tview));

--- a/plugins/send-by-mail/xviewer-send-by-mail.metainfo.xml.in
+++ b/plugins/send-by-mail/xviewer-send-by-mail.metainfo.xml.in
@@ -3,8 +3,8 @@
 <component type="addon">
   <id>xviewer-send-by-mail</id>
   <extends>xviewer.desktop</extends>
-  <_name>Send by Mail</_name>
-  <_summary>Sends an image attached to a new mail</_summary>
+  <name>Send by Mail</name>
+  <summary>Sends an image attached to a new mail</summary>
   <url type="homepage">https://github.com/linuxmint/xviewer-plugins</url>
   <url type="bugtracker">https://github.com/linuxmint/xviewer-plugins/issues</url>
   <metadata_license>CC0-1.0</metadata_license>

--- a/plugins/slideshowshuffle/meson.build
+++ b/plugins/slideshowshuffle/meson.build
@@ -1,19 +1,20 @@
 plugin_name = 'slideshowshuffle'
 
-custom_target(
-    '@0@-plugin-info'.format(plugin_name),
+i18n.merge_file(
     input: '@0@.plugin.desktop.in'.format(plugin_name),
     output: '@0@.plugin'.format(plugin_name),
-    command: [intltool_merge, '-d', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'desktop',
+    args: ['--keyword=Name', '--keyword=Description'],
+    po_dir: po_dir,
     install: true,
     install_dir: plugin_libdir,
 )
 
-custom_target(
-    '@0@-metadata'.format(plugin_name),
+i18n.merge_file(
     input: 'xviewer-@0@.metainfo.xml.in'.format(plugin_name),
     output: 'xviewer-@0@.metainfo.xml'.format(plugin_name),
-    command: [intltool_merge, '-x', '-u', po_dir, '@INPUT@', '@OUTPUT@'],
+    type: 'xml',
+    po_dir: po_dir,
     install: true,
     install_dir: metainfo_dir
 )

--- a/plugins/slideshowshuffle/slideshowshuffle.plugin.desktop.in
+++ b/plugins/slideshowshuffle/slideshowshuffle.plugin.desktop.in
@@ -2,8 +2,8 @@
 Loader=python3
 Module=slideshowshuffle
 IAge=2
-_Name=Slideshow Shuffle
+Name=Slideshow Shuffle
 Icon=media-playlist-shuffle-symbolic
-_Description=Shuffles images in slideshow mode
+Description=Shuffles images in slideshow mode
 Authors=Johannes Marbach <jm@rapidrabbit.de>
 Copyright=Copyright © 2008 Johannes Marbach

--- a/plugins/slideshowshuffle/xviewer-slideshowshuffle.metainfo.xml.in
+++ b/plugins/slideshowshuffle/xviewer-slideshowshuffle.metainfo.xml.in
@@ -3,8 +3,8 @@
 <component type="addon">
   <id>xviewer-slideshowshuffle</id>
   <extends>xviewer.desktop</extends>
-  <_name>Slideshow Shuffle</_name>
-  <_summary>Shuffles the photos in slideshow mode</_summary>
+  <name>Slideshow Shuffle</name>
+  <summary>Shuffles the photos in slideshow mode</summary>
   <url type="homepage">https://github.com/linuxmint/xviewer-plugins</url>
   <url type="bugtracker">https://github.com/linuxmint/xviewer-plugins/issues</url>
   <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
A collection of smaller improvements and fixes:

* build:
  * migrate from intltool to gettext
  * run `glib-compile-schemas` for non-debian builds
  * fix build warnings for plugins
    * map: check return value of `clutter_init`
    * postasa: replace deprecated `*_GET_INSTANCE_PRIVATE` usage
    * send by mail: remove unused variable
* send-by-mail:
  * fix runtime assertion error `gtk_container_foreach: assertion 'GTK_IS_CONTAINER (container)' failed` when closing xviewer with the send-by-mail plugin enabled.
  This is caused by the removal of the action group on exit. Refer to the documentation of `gtk_ui_manager_ensure_update()`.
  * free the action group gobject.
