### PR TITLE
Prevent EXIF plugin from changing statusbar height

### DIFF
--- a/plugins/exif-display/xviewer-exif-display-plugin.c
+++ b/plugins/exif-display/xviewer-exif-display-plugin.c
@@ -608,6 +608,8 @@ setup_statusbar_exif (XviewerExifDisplayPlugin *plugin)
 	if (plugin->enable_statusbar) {
 		plugin->statusbar_exif = gtk_statusbar_new ();
 		gtk_widget_set_size_request (plugin->statusbar_exif, 280, 10);
+		gtk_widget_set_margin_top (plugin->statusbar_exif, 0);
+		gtk_widget_set_margin_bottom (plugin->statusbar_exif, 0);
 		gtk_box_pack_end (GTK_BOX (statusbar),
 				  plugin->statusbar_exif,
 				  FALSE, FALSE, 0);


### PR DESCRIPTION
Previously, the EXIF plugin would increase the height of the statusbar when EXIF data were displayed in it. This change sets the top and bottom margin of the EXIF statusbar widget to zero, to prevent this height change.